### PR TITLE
Suggestion: Add Linting CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Animated Discord Logo
+[![Linting CI Actions Status](https://github.com/NNTin/discord-logo/workflows/Linting%20CI/badge.svg)](https://github.com/NNTin/discord-logo/actions)
 
 This project was inspired by [Discord's loading logo](https://canary.discordapp.com/assets/0bdc0497eb3a19e66f2b1e3d5741634c.webm).
 


### PR DESCRIPTION
This adds a linting CI badge to the readme. 

Should look like so:  [![Linting CI Actions Status](https://github.com/NNTin/discord-logo/workflows/Linting%20CI/badge.svg)](https://github.com/NNTin/discord-logo/actions)
